### PR TITLE
Use State Tool in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,3 @@
-language: python
-python:
-  - "3.6"
-
 # Install dependencies.
 install:
   - sh <(curl -q https://platform.activestate.com/dl/cli/install.sh) -n

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 
 # Install dependencies.
 install:
-  - sh <(curl -q https://platform.activestate.com/dl/cli/install.sh -n)
+  - sh <(curl -q https://platform.activestate.com/dl/cli/install.sh) -n
 
 before_script:
   - state activate

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,10 @@ python:
 
 # Install dependencies.
 install:
-  - pip install -r requirements.txt
+  - sh <(curl -q https://platform.activestate.com/dl/cli/install.sh)
+
+before_script:
+  - state activate
 
 # Run linting and tests.
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 
 # Install dependencies.
 install:
-  - sh <(curl -q https://platform.activestate.com/dl/cli/install.sh)
+  - sh <(curl -q https://platform.activestate.com/dl/cli/install.sh -n)
 
 before_script:
   - state activate

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,11 @@ install:
   - sh <(curl -q https://platform.activestate.com/dl/cli/install.sh) -n
 
 before_script:
-  - export VERBOSE=true
-  - state activate
 
 # Run linting and tests.
 script:
-  - pylint ./src
-  - flake8 ./src --statistics --count
-  - pytest
+  - state run lints
+  - state run tests
 
 # Turn email notifications off.
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ install:
   - sh <(curl -q https://platform.activestate.com/dl/cli/install.sh) -n
 
 before_script:
+  - export VERBOSE=true
   - state activate
 
 # Run linting and tests.

--- a/activestate.yaml
+++ b/activestate.yaml
@@ -1,3 +1,10 @@
 project: https://platform.activestate.com/shnewto/learn-python?commitID=c3e759c8-6b60-441c-ad84-7628a4fb542f
 languages:
 - name: python
+scripts:
+  - name: tests
+    value: pytest
+  - name: lints
+    value: |
+      pylint ./src
+      flake8 ./src --statistics --count


### PR DESCRIPTION
Swap out explicit installation steps in favor of using the state tool and a platform project for the Travis CI workflow. 